### PR TITLE
Add OWNERS file in git-clone repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,17 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- bobcatfish
+- vdemeester
+- vinamra28
+- QuanZhang-William
+- ywluogg
+## alumni
+# sbwsg
+# kimsterv
+# ImJasonH
+# dlorenc
+# chmouel
+# wlynch
+# afrittoli
+# dibyom


### PR DESCRIPTION
Add OWNERS file in git-clone repo.

The list is based on the org.yaml in community project and the community OWNERS file.

