### PR TITLE
Bootstrap a CI using GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/git" # Location of package manifests
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,35 @@
+name: Build
+
+on:
+  pull_request:
+    branches: ['main']
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+
+  build:
+    defaults:
+      run:
+        working-directory: image/git-init
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ['1.19', '1.20']
+    name: Build ${{ matrix.go-version }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+
+      - uses: golang/govulncheck-action@dd3ead030e4f2cf713062f7a3395191802364e13 # v1
+
+      - run: |
+          go build ./...
+          go test -run=^$ ./...

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,151 @@
+name: release
+
+#on:
+#  push:
+#    tags:
+#      - '*'
+# FIXME(vdemeester) Add commit + tag
+
+jobs:
+  goreleaser:
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+      tag_name: ${{ steps.tag.outputs.tag_name }}
+
+    defaults:
+      run:
+        working-directory: image/git-init
+
+    permissions:
+      packages: write
+      id-token: write
+      contents: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - run: git fetch --prune --unshallow
+
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: '1.20'
+          check-latest: true
+
+      # This installs the current latest release.
+      - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
+        with:
+          version: v0.13.0
+
+      - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3
+
+      - uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3.1.1
+
+      - name: Set tag output
+        id: tag
+        run: echo "tag_name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
+
+      - uses: goreleaser/goreleaser-action@3fa32b8bb5620a2c1afe798654bbad59f9da4906 # v4.4.0
+        id: run-goreleaser
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: sign ko-image
+        run: |
+          digest=$(crane digest "${REGISTRY}":"${GIT_TAG}")
+          cosign sign --yes \
+              -a GIT_HASH="${GIT_HASH}" \
+              -a GIT_TAG="${GIT_TAG}" \
+              -a RUN_ID="${RUN_ID}" \
+              -a RUN_ATTEMPT="${RUN_ATTEMPT}" \
+              "${REGISTRY}@${digest}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_HASH: ${{ github.sha }}
+          GIT_TAG: ${{ steps.tag.outputs.tag_name }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+          REGISTRY: "ghcr.io/${{ github.repository }}"
+
+      - name: Generate subject
+        id: hash
+        env:
+          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
+        run: |
+          set -euo pipefail
+
+          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+  provenance:
+    needs:
+      - goreleaser
+
+    permissions:
+      actions: read   # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.8.0
+    with:
+      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
+      upload-assets: true
+      upload-tag-name: "${{ needs.release.outputs.tag_name }}"
+
+  verification:
+    needs:
+      - goreleaser
+      - provenance
+
+    runs-on: ubuntu-latest
+    permissions: read-all
+
+    steps:
+      # Note: this will be replaced with the GHA in the future.
+      - name: Install the verifier
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          gh -R slsa-framework/slsa-verifier release download v1.3.2 -p "slsa-verifier-linux-amd64"
+          chmod ug+x slsa-verifier-linux-amd64
+          # Note: see https://github.com/slsa-framework/slsa-verifier/blob/main/SHA256SUM.md
+          COMPUTED_HASH=$(sha256sum slsa-verifier-linux-amd64 | cut -d ' ' -f1)
+          EXPECTED_HASH="b1d6c9bbce6274e253f0be33158cacd7fb894c5ebd643f14a911bfe55574f4c0"
+          if [[ "$EXPECTED_HASH" != "$COMPUTED_HASH" ]];then
+              echo "error: expected $EXPECTED_HASH, computed $COMPUTED_HASH"
+              exit 1
+          fi
+
+      - name: Download assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROVENANCE: "${{ needs.provenance.outputs.provenance-name }}"
+        run: |
+          set -euo pipefail
+
+          gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "*.tar.gz"
+          gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "$PROVENANCE"
+
+      - name: Verify assets
+        env:
+          CHECKSUMS: ${{ needs.goreleaser.outputs.hashes }}
+          PROVENANCE: "${{ needs.provenance.outputs.provenance-name }}"
+        run: |
+          set -euo pipefail
+
+          checksums=$(echo "$CHECKSUMS" | base64 -d)
+          while read -r line; do
+              fn=$(echo $line | cut -d ' ' -f2)
+
+              echo "Verifying $fn"
+              ./slsa-verifier-linux-amd64 -artifact-path "$fn" \
+                                      -provenance "$PROVENANCE" \
+                                      -source "github.com/$GITHUB_REPOSITORY" \
+                                      -tag "$GITHUB_REF_NAME"
+
+          done <<<"$checksums"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# git-clone

--- a/image/git-init/.goreleaser.yml
+++ b/image/git-init/.goreleaser.yml
@@ -1,0 +1,72 @@
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    - go mod tidy
+    - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
+
+builds:
+  - id: binary
+    main: ./main.go
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    goos:
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - s390x
+      - 386
+      - mips64le
+      - ppc64le
+      - riscv64
+
+kos:
+  - id: git-init-image
+    build: binary
+    main: .
+    base_image: golang:1.20
+    platforms:
+      - all
+    tags:
+      - '{{ .Tag }}'
+      - '{{ .FullCommit }}'
+      - latest
+    sbom: spdx
+    bare: true
+    preserve_import_paths: false
+    base_import_paths: false
+
+archives:
+  - id: with-version
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+  - id: without-version
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'


### PR DESCRIPTION
- Add a Build job to build the git-init image
- Add a dependabot configuration (to keep go packages and github actions
  up-to-date)
- Add a unfinished Release job and gorelease configuration
