### PR TITLE
update go

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: "image/git-init/go.mod"
+          cache-dependency-path: "image/git-init/go.sum"
 
       # FIXME: figure out how to configure or use golangci-lint
       # - uses: golang/govulncheck-action@dd3ead030e4f2cf713062f7a3395191802364e13 # v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: "image/git-init/go.mod"
+          cache-dependency-path: "image/git-init/go.sum"
 
       # This installs the current latest release.
       - uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d # v0.8

--- a/image/git-init/go.mod
+++ b/image/git-init/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd-catalog/git-clone/git-init
 
-go 1.20
+go 1.23
 
 require (
 	github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
- **Update go to 1.23**
- **.github/workflows: use cache-dependency-path for setup-go**
