### PR TITLE
fix: use --force when checking submodules

### DIFF
--- a/image/git-init/git/git.go
+++ b/image/git-init/git/git.go
@@ -246,7 +246,7 @@ func submoduleFetch(logger *zap.SugaredLogger, spec FetchSpec, retryConfig Retry
 			return fmt.Errorf("failed to change directory with path %s; err: %w", spec.Path, err)
 		}
 	}
-	updateArgs := []string{"submodule", "update", "--recursive", "--init"}
+	updateArgs := []string{"submodule", "update", "--recursive", "--init", "--force"}
 	if spec.Depth > 0 {
 		updateArgs = append(updateArgs, fmt.Sprintf("--depth=%d", spec.Depth))
 	}


### PR DESCRIPTION
When and error happens and retry is trigerred, repo gets into some semi-broken state, where submodules in repo aren't properly fetched, but `git submodule update --recursive --init` returns success. Only by adding --force ensures that broken submodule is re-fetched to a working state.

Use --force option to make sure, all submodules are fetched correctly. Give we clone new repos, and it's already used in the clone operation, it shouldn't break anything.