### PR TITLE
ci: fix release workflow failures

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,7 @@ jobs:
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true
-      upload-tag-name: "${{ needs.release.outputs.tag_name }}"
+      upload-tag-name: "${{ needs.goreleaser.outputs.tag_name }}"
 
   verification:
     needs:
@@ -113,11 +113,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh -R slsa-framework/slsa-verifier release download v1.3.2 -p "slsa-verifier-linux-amd64"
+          gh -R slsa-framework/slsa-verifier release download v2.7.1 -p "slsa-verifier-linux-amd64"
           chmod ug+x slsa-verifier-linux-amd64
           # Note: see https://github.com/slsa-framework/slsa-verifier/blob/main/SHA256SUM.md
           COMPUTED_HASH=$(sha256sum slsa-verifier-linux-amd64 | cut -d ' ' -f1)
-          EXPECTED_HASH="b1d6c9bbce6274e253f0be33158cacd7fb894c5ebd643f14a911bfe55574f4c0"
+          EXPECTED_HASH="946dbec729094195e88ef78e1734324a27869f03e2c6bd2f61cbc06bd5350339"
           if [[ "$EXPECTED_HASH" != "$COMPUTED_HASH" ]];then
               echo "error: expected $EXPECTED_HASH, computed $COMPUTED_HASH"
               exit 1
@@ -145,9 +145,9 @@ jobs:
               fn=$(echo $line | cut -d ' ' -f2)
 
               echo "Verifying $fn"
-              ./slsa-verifier-linux-amd64 -artifact-path "$fn" \
-                                      -provenance "$PROVENANCE" \
-                                      -source "github.com/$GITHUB_REPOSITORY" \
-                                      -tag "$GITHUB_REF_NAME"
+              ./slsa-verifier-linux-amd64 verify-artifact "$fn" \
+                                      --provenance-path "$PROVENANCE" \
+                                      --source-uri "github.com/$GITHUB_REPOSITORY" \
+                                      --source-tag "$GITHUB_REF_NAME"
 
           done <<<"$checksums"

--- a/image/git-init/.goreleaser.yml
+++ b/image/git-init/.goreleaser.yml
@@ -29,7 +29,7 @@ kos:
   - id: git-init-image
     build: binary
     main: .
-    base_image: golang:1.23
+    base_image: golang:1.25
     platforms:
       - all
     tags:


### PR DESCRIPTION
The v1.2.0 release failed at the `verification` step. This PR fixes 4 issues that would prevent a successful release:

1. **`needs.release` → `needs.goreleaser`** — the provenance job referenced a non-existent job name
2. **slsa-verifier v1.3.2 → v2.7.1** — the old verifier is incompatible with current provenance format
3. **v1 CLI flags → v2 subcommand** — `verify-artifact` with `--provenance-path`, `--source-uri`, `--source-tag`
4. **goreleaser base image `golang:1.23` → `golang:1.25`** — align with current go.mod