### PR TITLE
ci: add e2e tests with Kind cluster, migrate to v1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,33 +4,103 @@ on:
   pull_request:
     branches: ['main']
   push:
-    branches: [ main ]
+    branches: [main]
   schedule:
     - cron: '0 0 * * *'
 
-jobs:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
+    name: Build & Test
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: image/git-init
-
-    name: Build
-    runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "image/git-init/go.mod"
           cache-dependency-path: "image/git-init/go.sum"
-
-      # FIXME: figure out how to configure or use golangci-lint
-      # - uses: golang/govulncheck-action@dd3ead030e4f2cf713062f7a3395191802364e13 # v1
-      #   with:
-      #     go-package: ./image/git-init/...
-      #     go-version-input: ${{ matrix.go-version }}
-
       - run: go build ./...
       - run: go vet ./...
       - run: go test ./...
+
+  e2e:
+    name: E2E (${{ matrix.pipeline-version }})
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # All supported Tekton Pipelines LTS versions
+        # Update quarterly when new LTS is released
+        pipeline-version:
+          - v1.12.0  # LTS, EOL 2027-05-04
+          - v1.9.3   # LTS, EOL 2027-01-30
+          - v1.6.2   # LTS, EOL 2026-10-31
+          - v1.3.4   # LTS, EOL 2026-08-04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "image/git-init/go.mod"
+          cache-dependency-path: "image/git-init/go.sum"
+
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+
+      - name: Create Kind cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          cluster_name: kind
+          wait: 120s
+
+      - name: Build and load image into Kind
+        env:
+          KO_DOCKER_REPO: kind.local
+        run: |
+          cd image/git-init
+          ko build --sbom=none -B -t e2e .
+          echo "GIT_INIT_IMAGE=kind.local/git-init:e2e" >> "$GITHUB_ENV"
+
+      - name: Run e2e tests
+        env:
+          PIPELINE_VERSION: ${{ matrix.pipeline-version }}
+          TIMEOUT: 180s
+        run: ./test/e2e-tests.sh
+
+  ci-summary:
+    name: CI summary
+    needs: [build, e2e]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check CI results
+        run: |
+          results=(
+            "build=${NEEDS_BUILD_RESULT}"
+            "e2e=${NEEDS_E2E_RESULT}"
+          )
+          failed=0
+          for r in "${results[@]}"; do
+            name="${r%%=*}"
+            result="${r#*=}"
+            echo "${name}: ${result}"
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              failed=1
+            fi
+          done
+          if [ "$failed" -eq 1 ]; then
+            echo ""
+            echo "Some CI jobs failed or were cancelled"
+            exit 1
+          fi
+          echo ""
+          echo "All CI checks passed"
+        env:
+          NEEDS_BUILD_RESULT: ${{ needs.build.result }}
+          NEEDS_E2E_RESULT: ${{ needs.e2e.result }}

--- a/image/git-init/.goreleaser.yml
+++ b/image/git-init/.goreleaser.yml
@@ -29,7 +29,7 @@ kos:
   - id: git-init-image
     build: binary
     main: .
-    base_image: cgr.dev/chainguard/git
+    base_image: ghcr.io/tektoncd/plumbing/alpine-git-nonroot:latest
     platforms:
       - all
     tags:

--- a/image/git-init/.ko.yaml
+++ b/image/git-init/.ko.yaml
@@ -1,5 +1,1 @@
-defaultBaseImage: cgr.dev/chainguard/static
-baseImageOverrides:
-  # git-init uses a base image that includes Git, and supports running either
-  # as root or as user nonroot with UID 65532.
-  github.com/tektoncd-catalog/git-clone/image/git-init: cgr.dev/chainguard/git
+defaultBaseImage: ghcr.io/tektoncd/plumbing/alpine-git-nonroot:latest

--- a/task/git-clone/git-clone.yaml
+++ b/task/git-clone/git-clone.yaml
@@ -137,7 +137,7 @@ spec:
       description: |
         Absolute path to the user's home directory.
       type: string
-      default: "/home/git"
+      default: "/tekton/home"
   results:
     - name: commit
       description: The precise commit SHA that was fetched by this Task.
@@ -203,12 +203,15 @@ spec:
         runAsNonRoot: true
         runAsUser: 65532
       script: |
-        #!/usr/bin/env sh
+        #!/bin/sh
         set -eu
 
         if [ "${PARAM_VERBOSE}" = "true" ] ; then
           set -x
         fi
+
+        # Ensure the user home directory exists (it may not in minimal images)
+        mkdir -p "${PARAM_USER_HOME}"
 
         if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
           cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"

--- a/task/git-clone/samples/git-clone-checking-out-a-branch.yaml
+++ b/task/git-clone/samples/git-clone-checking-out-a-branch.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: cat-branch-readme
@@ -52,7 +52,7 @@ spec:
           #!/usr/bin/env zsh
           cat $(workspaces.source.path)/README.md
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: git-clone-checking-out-a-branch

--- a/task/git-clone/samples/git-clone-checking-out-a-commit.yaml
+++ b/task/git-clone/samples/git-clone-checking-out-a-commit.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: checking-out-a-revision
@@ -88,7 +88,7 @@ spec:
             echo "Saw README with owner of $detectedUID as expected."
           fi
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   generateName: git-clone-checking-out-a-commit-

--- a/task/git-clone/samples/git-clone-for-ssl-ca.yaml
+++ b/task/git-clone/samples/git-clone-for-ssl-ca.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: cat-readme
@@ -53,7 +53,7 @@ spec:
           #!/usr/bin/env zsh
           cat $(workspaces.source.path)/README.md
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: git-clone-checking-out-a-branch

--- a/task/git-clone/samples/git-clone-sparse-checkout.yaml
+++ b/task/git-clone/samples/git-clone-sparse-checkout.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: sparse-checkout-list-dir
@@ -53,7 +53,7 @@ spec:
           #!/usr/bin/env zsh
           ls -R $(workspaces.source.path)/
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: git-clone-sparse-checkout

--- a/task/git-clone/samples/using-git-clone-result.yaml
+++ b/task/git-clone/samples/using-git-clone-result.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: validate-tag-sha
@@ -59,7 +59,7 @@ spec:
             echo "Revision $(params.revision-name) has expected SHA $(params.expected-sha)."
           fi
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   generateName: using-git-clone-result-

--- a/task/git-clone/tests/run.yaml
+++ b/task/git-clone/tests/run.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-clone-run-noargs
@@ -16,7 +16,7 @@ spec:
     - name: url
       value: https://github.com/kelseyhightower/nocode
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-clone-run-tag
@@ -35,7 +35,7 @@ spec:
     - name: revision
       value: 1.0.0
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-clone-run-no-submodules
@@ -54,7 +54,7 @@ spec:
     - name: submodules
       value: "false"
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-clone-run-submodules-with-paths
@@ -73,7 +73,7 @@ spec:
     - name: submodulePaths
       value: "js"
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-clone-run-no-depth-2
@@ -92,7 +92,7 @@ spec:
     - name: depth
       value: "2"
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-clone-run-sslverify-none
@@ -111,7 +111,7 @@ spec:
     - name: sslVerify
       value: "false"
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-clone-run-ssl-cadirectory-empty
@@ -132,7 +132,7 @@ spec:
     - name: crtFileName
       value: ""
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-clone-run-subdirectory
@@ -151,7 +151,7 @@ spec:
     - name: subdirectory
       value: "hellomoto"
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-clone-run-delete-existing
@@ -170,7 +170,7 @@ spec:
     - name: deleteExisting
       value: "true"
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-clone-run-without-verbose
@@ -189,7 +189,7 @@ spec:
     - name: verbose
       value: "false"
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-clone-sparse

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Simple e2e test runner for git-clone task.
+# Installs the task, runs all TaskRuns from tests/run.yaml, and waits for completion.
+#
+# Environment variables:
+#   PIPELINE_VERSION  - Tekton Pipelines version to install (default: v1.12.0)
+#   TIMEOUT           - Timeout for each TaskRun (default: 120s)
+#   GIT_INIT_IMAGE    - Override the gitInitImage in the task (optional, for testing local builds)
+
+set -euo pipefail
+
+PIPELINE_VERSION="${PIPELINE_VERSION:-v1.12.0}"
+TIMEOUT="${TIMEOUT:-120s}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "--- Installing Tekton Pipelines ${PIPELINE_VERSION}"
+kubectl apply --filename "https://github.com/tektoncd/pipeline/releases/download/${PIPELINE_VERSION}/release.yaml"
+echo "--- Waiting for Tekton Pipelines to be ready"
+kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-controller -n tekton-pipelines
+kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-webhook -n tekton-pipelines
+
+echo "--- Installing git-clone task"
+if [[ -n "${GIT_INIT_IMAGE:-}" ]]; then
+    echo "    Using locally built image: ${GIT_INIT_IMAGE}"
+    sed "s|ghcr.io/tektoncd-catalog/git-clone:[^ \"]*|${GIT_INIT_IMAGE}|g" \
+        "${ROOT_DIR}/task/git-clone/git-clone.yaml" | kubectl apply -f -
+else
+    kubectl apply -f "${ROOT_DIR}/task/git-clone/git-clone.yaml"
+fi
+
+echo "--- Creating test TaskRuns"
+kubectl apply -f "${ROOT_DIR}/task/git-clone/tests/run.yaml"
+
+# Collect all TaskRun names
+TASKRUNS=$(kubectl get taskrun -o name | sed 's|taskrun.tekton.dev/||')
+
+FAILED=0
+PASSED=0
+TOTAL=0
+
+echo "--- Waiting for TaskRuns to complete (timeout: ${TIMEOUT})"
+for tr in ${TASKRUNS}; do
+    TOTAL=$((TOTAL + 1))
+    echo -n "  ${tr} ... "
+    if kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" taskrun/"${tr}" 2>/dev/null; then
+        echo "PASSED"
+        PASSED=$((PASSED + 1))
+    else
+        echo "FAILED"
+        echo "  --- TaskRun status ---"
+        kubectl get taskrun/"${tr}" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
+        echo ""
+        echo "  --- Pod logs ---"
+        pod=$(kubectl get taskrun/"${tr}" -o jsonpath='{.status.podName}' 2>/dev/null)
+        if [[ -n "${pod}" ]]; then
+            kubectl logs "${pod}" --all-containers 2>/dev/null || true
+        fi
+        echo "  ---"
+        FAILED=$((FAILED + 1))
+    fi
+done
+
+echo ""
+echo "=== Results: ${PASSED}/${TOTAL} passed, ${FAILED} failed ==="
+
+if [[ ${FAILED} -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Changes

Depends on #110.

### Migrate test resources to v1

All TaskRuns in `task/git-clone/tests/run.yaml` and samples in `task/git-clone/samples/` are updated from `tekton.dev/v1beta1` to `tekton.dev/v1`.

### Add e2e test infrastructure

Simple e2e setup that:
1. Spins up a Kind cluster via `helm/kind-action`
2. Installs Tekton Pipelines at the specified version
3. Installs the git-clone task
4. Runs all 11 TaskRuns from `tests/run.yaml`
5. Waits for completion and reports pass/fail

Tests run against two Tekton Pipelines LTS versions:
- v1.12.0 (current LTS)
- v1.6.0 (previous LTS)

This is intentionally simpler than the tektoncd/catalog e2e setup — no registry, no plumbing scripts, no change detection. Just Kind + Tekton + TaskRuns.

### What was wrong with CI before

The build workflow had `go test -run=^$ ./...` which matches **zero** test names — it only compiled tests without running them. That's fixed in #110. This PR adds the missing task-level e2e tests.

## Release Notes

```release-note
NONE
```