### PR TITLE
fix: use chainguard/git base image for releases

### DIFF
--- a/image/git-init/.goreleaser.yml
+++ b/image/git-init/.goreleaser.yml
@@ -29,7 +29,7 @@ kos:
   - id: git-init-image
     build: binary
     main: .
-    base_image: golang:1.25
+    base_image: cgr.dev/chainguard/git
     platforms:
       - all
     tags:


### PR DESCRIPTION
<!-- Thank you for the PR! -->

# Changes

The goreleaser `kos:` section used `golang:1.25` (808MB) as the base image for
release container images. Goreleaser ignores `.ko.yaml`, so even though `.ko.yaml`
correctly specifies `cgr.dev/chainguard/git`, releases were built with the full
Go SDK image.

This results in:
- **808MB image** instead of 76MB
- Hundreds of unnecessary packages (compilers, tools, libraries)
- Poor security scan results on Artifact Hub due to CVEs in unrelated packages

Switched to `cgr.dev/chainguard/git` — a minimal image with only git and its
dependencies, maintained and patched by Chainguard.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) for new or changed functionality
- [x] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) for user-facing changes
- [x] Commit messages follow [best practices](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)

# Release Notes

```release-note
Switch release image base from golang:1.25 (808MB) to cgr.dev/chainguard/git (76MB), reducing image size and CVE surface.
```