### PR TITLE
feat: publish Tekton Bundle on release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,9 +73,45 @@ jobs:
           TIMEOUT: 180s
         run: ./test/e2e-tests.sh
 
+  e2e-bundle:
+    name: E2E Bundle
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "image/git-init/go.mod"
+          cache-dependency-path: "image/git-init/go.sum"
+
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+
+      - uses: tektoncd/actions/setup-tektoncd-cli@dd92514472167b361de1c95fd31fc2ef83c282ec # main
+
+      - name: Create Kind cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          cluster_name: kind
+          wait: 120s
+
+      - name: Build and load image into Kind
+        env:
+          KO_DOCKER_REPO: kind.local
+        run: |
+          cd image/git-init
+          ko build --sbom=none -B -t e2e .
+          echo "GIT_INIT_IMAGE=kind.local/git-init:e2e" >> "$GITHUB_ENV"
+
+      - name: Run bundle e2e test
+        env:
+          PIPELINE_VERSION: v1.12.0
+          TIMEOUT: 180s
+        run: ./test/e2e-bundle-test.sh
+
   ci-summary:
     name: CI summary
-    needs: [build, e2e]
+    needs: [build, e2e, e2e-bundle]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -84,6 +120,7 @@ jobs:
           results=(
             "build=${NEEDS_BUILD_RESULT}"
             "e2e=${NEEDS_E2E_RESULT}"
+            "e2e-bundle=${NEEDS_E2E_BUNDLE_RESULT}"
           )
           failed=0
           for r in "${results[@]}"; do
@@ -104,3 +141,4 @@ jobs:
         env:
           NEEDS_BUILD_RESULT: ${{ needs.build.result }}
           NEEDS_E2E_RESULT: ${{ needs.e2e.result }}
+          NEEDS_E2E_BUNDLE_RESULT: ${{ needs.e2e-bundle.result }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,32 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Push Tekton Bundle
+        uses: tektoncd/actions/setup-tektoncd-cli@dd92514472167b361de1c95fd31fc2ef83c282ec # main
+
+      - name: Publish Tekton Bundle
+        working-directory: .
+        env:
+          GIT_TAG: ${{ steps.tag.outputs.tag_name }}
+          REGISTRY: "ghcr.io/${{ github.repository }}"
+        run: |
+          tkn bundle push "${REGISTRY}/bundle:${GIT_TAG}" \
+            -f task/git-clone/git-clone.yaml
+          tkn bundle push "${REGISTRY}/bundle:latest" \
+            -f task/git-clone/git-clone.yaml
+
+      - name: Sign Tekton Bundle
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_TAG: ${{ steps.tag.outputs.tag_name }}
+          REGISTRY: "ghcr.io/${{ github.repository }}"
+        run: |
+          digest=$(crane digest "${REGISTRY}/bundle:${GIT_TAG}")
+          cosign sign --yes \
+              -a GIT_HASH="${{ github.sha }}" \
+              -a GIT_TAG="${GIT_TAG}" \
+              "${REGISTRY}/bundle@${digest}"
+
       - name: sign ko-image
         run: |
           digest=$(crane digest "${REGISTRY}":"${GIT_TAG}")

--- a/README.md
+++ b/README.md
@@ -11,10 +11,24 @@ checkouts via the `sparseCheckoutDirectories` param.
 
 ## Installation
 
-Install the Task:
+Install the Task directly:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/git-clone/main/task/git-clone/git-clone.yaml
+```
+
+Or use the [Tekton Bundle](https://tekton.dev/docs/pipelines/tekton-bundle-contracts/) with the bundle resolver:
+
+```yaml
+taskRef:
+  resolver: bundles
+  params:
+    - name: bundle
+      value: ghcr.io/tektoncd-catalog/git-clone/bundle:v1.4.0
+    - name: name
+      value: git-clone
+    - name: kind
+      value: task
 ```
 
 ## Usage

--- a/test/e2e-bundle-test.sh
+++ b/test/e2e-bundle-test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# E2e test for Tekton Bundle publishing.
+# Pushes the task as a bundle to ttl.sh, then runs a TaskRun that
+# references it via the bundle resolver.
+#
+# Environment variables:
+#   PIPELINE_VERSION  - Tekton Pipelines version to install (default: v1.12.0)
+#   TIMEOUT           - Timeout for TaskRun (default: 120s)
+#   GIT_INIT_IMAGE    - Override the gitInitImage in the task (optional)
+#   BUNDLE_REGISTRY   - Registry to push bundles to (default: ttl.sh)
+
+set -euo pipefail
+
+PIPELINE_VERSION="${PIPELINE_VERSION:-v1.12.0}"
+TIMEOUT="${TIMEOUT:-120s}"
+BUNDLE_REGISTRY="${BUNDLE_REGISTRY:-ttl.sh}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Generate a unique bundle reference
+BUNDLE_REF="${BUNDLE_REGISTRY}/git-clone-e2e-$(head -c 8 /proc/sys/kernel/random/uuid):1h"
+
+echo "--- Installing Tekton Pipelines ${PIPELINE_VERSION}"
+kubectl apply --filename "https://github.com/tektoncd/pipeline/releases/download/${PIPELINE_VERSION}/release.yaml"
+echo "--- Waiting for Tekton Pipelines to be ready"
+kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-controller -n tekton-pipelines
+kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-webhook -n tekton-pipelines
+
+# Prepare the task YAML (with optional image override)
+TASK_YAML=$(mktemp)
+if [[ -n "${GIT_INIT_IMAGE:-}" ]]; then
+    echo "    Using locally built image: ${GIT_INIT_IMAGE}"
+    sed "s|ghcr.io/tektoncd-catalog/git-clone:[^ \"]*|${GIT_INIT_IMAGE}|g" \
+        "${ROOT_DIR}/task/git-clone/git-clone.yaml" > "${TASK_YAML}"
+else
+    cp "${ROOT_DIR}/task/git-clone/git-clone.yaml" "${TASK_YAML}"
+fi
+
+echo "--- Pushing Tekton Bundle to ${BUNDLE_REF}"
+tkn bundle push "${BUNDLE_REF}" -f "${TASK_YAML}"
+
+echo "--- Creating TaskRun using bundle resolver"
+cat <<EOF | kubectl apply -f -
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: git-clone-bundle-test
+spec:
+  taskRef:
+    resolver: bundles
+    params:
+      - name: bundle
+        value: ${BUNDLE_REF}
+      - name: name
+        value: git-clone
+      - name: kind
+        value: task
+  workspaces:
+    - name: output
+      emptyDir: {}
+  podTemplate:
+    securityContext:
+      fsGroup: 65532
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+EOF
+
+echo "--- Waiting for TaskRun to complete (timeout: ${TIMEOUT})"
+if kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" taskrun/git-clone-bundle-test 2>/dev/null; then
+    echo ""
+    echo "=== Bundle test PASSED ==="
+else
+    echo ""
+    echo "=== Bundle test FAILED ==="
+    kubectl get taskrun/git-clone-bundle-test -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
+    echo ""
+    pod=$(kubectl get taskrun/git-clone-bundle-test -o jsonpath='{.status.podName}' 2>/dev/null)
+    if [[ -n "${pod}" ]]; then
+        kubectl logs "${pod}" --all-containers 2>/dev/null || true
+    fi
+    exit 1
+fi
+
+rm -f "${TASK_YAML}"


### PR DESCRIPTION
<!-- Thank you for the PR! -->

# Changes

Publish the git-clone Task as a [Tekton Bundle](https://tekton.dev/docs/pipelines/tekton-bundle-contracts/) on every release.

### Release workflow additions

Three new steps in the `goreleaser` job, after the container image is built and before it's signed:

1. **Install tkn** — via `tektoncd/actions/setup-tektoncd-cli` (pinned to commit SHA)
2. **Push bundle** — `tkn bundle push` to `ghcr.io/tektoncd-catalog/git-clone/bundle:{tag}` and `:latest`
3. **Sign bundle** — cosign signs the bundle digest (same key/flow as the container image)

### Usage

```yaml
taskRef:
  resolver: bundles
  params:
    - name: bundle
      value: ghcr.io/tektoncd-catalog/git-clone/bundle:v1.4.0
    - name: name
      value: git-clone
    - name: kind
      value: task
```

Closes #113

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) for new or changed functionality
- [x] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) for user-facing changes
- [x] Commit messages follow [best practices](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)

# Release Notes

```release-note
Publish git-clone Task as a signed Tekton Bundle to ghcr.io on every release.
```