### PR TITLE
feat: add custom base image with git-lfs, openssh, uid 65532

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/image/base"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -1,0 +1,35 @@
+name: Base Image
+
+on:
+  push:
+    branches: [main]
+    paths: ['image/base/**']
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday — catch upstream updates
+  workflow_dispatch: {}
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    name: Build and push base image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        with:
+          context: image/base
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/base:latest
+            ghcr.io/${{ github.repository }}/base:${{ github.sha }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,9 +59,15 @@ jobs:
           cluster_name: kind
           wait: 120s
 
+      - name: Build base image
+        run: |
+          docker build -t ghcr.io/${{ github.repository }}/base:latest image/base/
+          docker tag ghcr.io/${{ github.repository }}/base:latest ko.local/git-clone-base:latest
+
       - name: Build and load image into Kind
         env:
           KO_DOCKER_REPO: kind.local
+          KO_DEFAULTBASEIMAGE: ko.local/git-clone-base:latest
         run: |
           cd image/git-init
           ko build --sbom=none -B -t e2e .
@@ -95,9 +101,15 @@ jobs:
           cluster_name: kind
           wait: 120s
 
+      - name: Build base image
+        run: |
+          docker build -t ghcr.io/${{ github.repository }}/base:latest image/base/
+          docker tag ghcr.io/${{ github.repository }}/base:latest ko.local/git-clone-base:latest
+
       - name: Build and load image into Kind
         env:
           KO_DOCKER_REPO: kind.local
+          KO_DEFAULTBASEIMAGE: ko.local/git-clone-base:latest
         run: |
           cd image/git-init
           ko build --sbom=none -B -t e2e .

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Base image for git-clone task.
+# Includes git, git-lfs, openssh-client, and a nonroot user (uid 65532)
+# matching Tekton's default securityContext.
+FROM docker.io/alpine/git:v2.52.0@sha256:8786a6a02273827d0aa039d174aacd5e017fcce9aba0af62596d991970cab01a
+
+RUN apk add --no-cache git-lfs openssh-client && \
+    adduser -D -u 65532 -G root tekton && \
+    mkdir -p /home/tekton && chown tekton:root /home/tekton
+
+USER tekton

--- a/image/git-init/.goreleaser.yml
+++ b/image/git-init/.goreleaser.yml
@@ -29,7 +29,7 @@ kos:
   - id: git-init-image
     build: binary
     main: .
-    base_image: ghcr.io/tektoncd/plumbing/alpine-git-nonroot:latest
+    base_image: ghcr.io/tektoncd-catalog/git-clone/base:latest
     platforms:
       - all
     tags:

--- a/image/git-init/.ko.yaml
+++ b/image/git-init/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: ghcr.io/tektoncd/plumbing/alpine-git-nonroot:latest
+defaultBaseImage: ghcr.io/tektoncd-catalog/git-clone/base:latest


### PR DESCRIPTION
<!-- Thank you for the PR! -->

# Changes

Add a custom base image owned by this repo, replacing the dependency on `ghcr.io/tektoncd/plumbing/alpine-git-nonroot`.

### Base image (`image/base/Dockerfile`)

```dockerfile
FROM docker.io/alpine/git:v2.52.0@sha256:8786a6a0...
RUN apk add --no-cache git-lfs openssh-client && \
    adduser -D -u 65532 -G root tekton
USER tekton
```

Includes everything the task needs:
- **git** — from the base `alpine/git`
- **git-lfs** — fixes #71
- **openssh-client** — needed for SSH clones
- **uid 65532 in /etc/passwd** — fixes #85 (SSH requires passwd entry)
- **coreutils** (busybox) — `rm`, `basename`, `sed`, etc.

### Build and update strategy

- `base-image.yaml` workflow: builds on Dockerfile change + weekly schedule
- Dependabot docker ecosystem watches `FROM` digest for upstream updates
- E2e workflows build the base image locally so CI works without pre-published image

### Why not `ghcr.io/tektoncd/plumbing/alpine-git-nonroot`?

- We don't control it — updates are on someone else's schedule
- It uses uid 1000, we need uid 65532 (matching the task's `securityContext`)
- Missing git-lfs
- Transitive dependency on another repo's CI

Fixes #85

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) for new or changed functionality
- [x] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) for user-facing changes
- [x] Commit messages follow [best practices](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)

# Release Notes

```release-note
Custom base image with git, git-lfs, openssh-client, and uid 65532 — fixes SSH clone failures as non-root and adds git-lfs support.
```