### PR TITLE
docs: add DEVELOPMENT.md, CONTRIBUTING.md, and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ detail see [DEVELOPMENT.md](DEVELOPMENT.md).
 | `hack/release.sh` | Release automation. |
 | `hack/apply-ah-changes.py` | Injects the `artifacthub.io/changes` annotation at release. |
 | `test/` | e2e runners (`e2e-tests.sh`, `e2e-bundle-test.sh`). |
-| `keys/` | `cosign.pub` and signing material. |
+| `keys/` | `cosign.pub`, the public key for verifying signed release bundles. |
 | `.github/workflows/` | `build.yaml` (test/verify/e2e), `release.yaml` (bundle publish), `base-image.yaml`. |
 
 ## Critical Rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in `tektoncd-catalog/git-clone`. For full
+detail see [DEVELOPMENT.md](DEVELOPMENT.md).
+
+## Repository structure
+
+| Path | Role |
+|------|------|
+| `task/git-clone/git-clone.yaml` | **Edit this.** The `git-clone` Task — the single source of truth. |
+| `stepaction/git-clone/git-clone.yaml` | **Generated — never edit by hand.** Derived from the Task. |
+| `image/git-init/` | Go source for the `git-init` binary the Task runs (built with `ko`). |
+| `image/base/Dockerfile` | Base image the `git-init` image is built `FROM`. |
+| `hack/generate-stepaction.sh` | Wrapper around the Python generator. |
+| `hack/generate-stepaction.py` | Derives the StepAction from the Task (workspaces → params). |
+| `hack/release.sh` | Release automation. |
+| `hack/apply-ah-changes.py` | Injects the `artifacthub.io/changes` annotation at release. |
+| `test/` | e2e runners (`e2e-tests.sh`, `e2e-bundle-test.sh`). |
+| `keys/` | `cosign.pub` and signing material. |
+| `.github/workflows/` | `build.yaml` (test/verify/e2e), `release.yaml` (bundle publish), `base-image.yaml`. |
+
+## Critical Rules
+
+1. **Never edit `stepaction/git-clone/git-clone.yaml` directly.** It is
+   generated from the Task. Edit `task/git-clone/git-clone.yaml`, then run
+   `./hack/generate-stepaction.sh`. CI's *Verify StepAction is in sync* step
+   diffs the committed file against a freshly generated one and fails on
+   mismatch.
+2. **No `$(params.*)` in `script:` blocks.** For StepActions `$(params.*)` in
+   scripts is not supported at all; in both Task and StepAction it's an
+   injection risk. Pass values via `env:` and reference the shell env var
+   (e.g. `${PARAM_OUTPUT_PATH}`, `${WORKSPACE_OUTPUT_PATH}`).
+3. **Workspaces map to params in the StepAction.** `output` → `output-path`,
+   `ssh-directory` → `ssh-directory-path`, `basic-auth` → `basic-auth-path`,
+   `ssl-ca-directory` → `ssl-ca-directory-path`. The `WORKSPACE_*_PATH` env
+   vars become `PARAM_*`; the `WORKSPACE_*_BOUND` booleans are dropped. If you
+   change a workspace, update `WORKSPACE_PARAMS` / `WORKSPACE_ENV_MAP` and the
+   `transform_*` functions in `hack/generate-stepaction.py`.
+4. **Sign off every commit** (DCO / EasyCLA): `git commit --signoff`.
+5. **Use conventional commit prefixes** (`feat:`, `fix:`, `docs:`, `chore:`,
+   `ci:`) — the release changelog is derived from them.
+6. **Do not add a `tekton.dev/signature` to the StepAction** — the generator
+   drops it. Trusted Resources signing is intentionally not done in-repo
+   (blocked by tektoncd/cli#2894 and tektoncd/cli#2895); the bundle and image
+   are cosign-signed in the release workflow.
+
+## Common commands
+
+```bash
+./hack/generate-stepaction.sh             # regenerate the StepAction from the Task
+./hack/release.sh v1.8.0 --dry-run         # preview a release (no changes applied)
+./hack/release.sh v1.8.0 --dry-run --llm   # preview with gh copilot changelog
+./test/e2e-tests.sh                       # e2e in a kind cluster (needs a cluster)
+./test/e2e-bundle-test.sh                 # bundle-resolver e2e
+(cd image/git-init && go test ./...)      # unit tests for the git-init binary
+```
+
+Generation needs `python3` with PyYAML (falls back to `uv tool run --with
+pyyaml`).
+
+## Validating changes locally
+
+1. After editing the Task, run `./hack/generate-stepaction.sh`.
+2. Confirm `git status` shows only intended changes (clean verify step).
+3. Run `go build/vet/test` under `image/git-init` if you touched the binary.
+4. Run the relevant e2e script against a kind cluster.
+5. Update `README.md` if you changed installation or usage.
+
+## Common pitfalls
+
+- Forgetting to run `./hack/generate-stepaction.sh` after editing the Task →
+  CI *Verify StepAction is in sync* fails.
+- Editing `stepaction/git-clone/git-clone.yaml` by hand → overwritten on the
+  next regeneration and rejected by CI.
+- Putting `$(params.*)` in a `script:` block → use env vars instead.
+- Adding a new workspace without updating the generator's mapping tables →
+  the StepAction won't expose the corresponding param.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ Every PR runs `.github/workflows/build.yaml`, which must pass:
   fails if the committed `stepaction/` file differs from a freshly generated
   one. If this fails, run `./hack/generate-stepaction.sh` and commit the result.
 - **E2E matrix** — installs the Task in a kind cluster and runs the TaskRuns in
-  `tests/run.yaml` across the supported Tekton Pipelines versions, plus the
-  bundle e2e test.
+  `task/git-clone/tests/run.yaml` and `stepaction/git-clone/tests/run.yaml`
+  across the supported Tekton Pipelines versions, plus the bundle e2e test.
 
 > [!TIP]
 > Before pushing, run `./hack/generate-stepaction.sh` and make sure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+Thanks for your interest in contributing to `tektoncd-catalog/git-clone`! This
+repository is part of the Tekton Catalog and follows the broader
+[tektoncd-catalog contributing guide](https://github.com/tektoncd-catalog/.github/blob/main/CONTRIBUTING.md).
+
+For technical details on how the repo is structured and generated, see
+[DEVELOPMENT.md](DEVELOPMENT.md).
+
+## Developer Certificate of Origin (DCO) / CLA
+
+All commits must be signed off to certify the
+[Developer Certificate of Origin](https://developercertificate.org/). Add a
+`Signed-off-by` trailer to every commit:
+
+```bash
+git commit --signoff -m "fix: handle empty ssh-directory path"
+```
+
+The sign-off line must match the author's name and email. Contributions are
+also covered by the Linux Foundation
+[EasyCLA](https://github.com/tektoncd/community/blob/main/process.md#contributor-license-agreements)
+check, which runs on pull requests — follow its prompt to sign the CLA the
+first time you contribute.
+
+## Pull request workflow
+
+1. **Fork and branch** from `main`.
+2. **Edit the Task** (`task/git-clone/git-clone.yaml`) and/or the `git-init`
+   image (`image/git-init/`) — never edit the generated
+   `stepaction/git-clone/git-clone.yaml` directly.
+3. **Regenerate** the StepAction and commit both files:
+   ```bash
+   ./hack/generate-stepaction.sh
+   git add task/ stepaction/
+   ```
+4. **Test locally** (see [DEVELOPMENT.md](DEVELOPMENT.md#running-tests-locally)).
+5. **Use conventional commit messages** (`feat:`, `fix:`, `docs:`, `chore:`,
+   `ci:`) — the release changelog is derived from these prefixes.
+6. **Open a PR** with a clear description.
+
+Approvals are managed via `OWNERS` (Prow-based auto-merge).
+
+## CI expectations
+
+Every PR runs `.github/workflows/build.yaml`, which must pass:
+
+- **Build & Test** — `go build ./...`, `go vet ./...`, and `go test ./...` in
+  `image/git-init`.
+- **Verify StepAction is in sync** — runs `./hack/generate-stepaction.sh` and
+  fails if the committed `stepaction/` file differs from a freshly generated
+  one. If this fails, run `./hack/generate-stepaction.sh` and commit the result.
+- **E2E matrix** — installs the Task in a kind cluster and runs the TaskRuns in
+  `tests/run.yaml` across the supported Tekton Pipelines versions, plus the
+  bundle e2e test.
+
+> [!TIP]
+> Before pushing, run `./hack/generate-stepaction.sh` and make sure
+> `git status` is clean (apart from your intended changes). A stale StepAction
+> is the most common CI failure.
+
+## Code of conduct
+
+This project follows the Tekton
+[Code of Conduct](https://github.com/tektoncd/community/blob/main/code-of-conduct.md).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,189 @@
+# Development
+
+This document explains how the `tektoncd-catalog/git-clone` repository is
+structured and how to develop, generate, test, and release its Task and
+StepAction.
+
+> [!IMPORTANT]
+> The `task/` directory is the **source of truth**. The `stepaction/` directory
+> is **generated** from it. Never edit `stepaction/git-clone/git-clone.yaml`
+> directly — edit the Task and run `./hack/generate-stepaction.sh`.
+
+## Architecture overview
+
+The repository ships a `git-clone` [Task](task/git-clone/) and a derived
+[StepAction](stepaction/git-clone/) for Tekton Pipelines. Both run the
+`git-init` binary built from `image/git-init/`.
+
+```
+image/git-init/  ──► ko build ──► git-init image (gitInitImage param)
+                                        │
+task/git-clone/git-clone.yaml  ─────────┤  (source of truth)
+        │                               │
+        └─► hack/generate-stepaction.py ┴─► stepaction/git-clone/git-clone.yaml
+                                            (generated — do not edit)
+```
+
+Key files:
+
+| Path | Role |
+|------|------|
+| `task/git-clone/git-clone.yaml` | **Hand-edited.** The `git-clone` Task — the single source of truth. |
+| `stepaction/git-clone/git-clone.yaml` | **Generated** from the Task. Do not edit. |
+| `image/git-init/` | Go source for the `git-init` binary the Task runs (built with `ko`). |
+| `image/base/Dockerfile` | Base image (git + tooling) the `git-init` image is built `FROM`. |
+| `hack/generate-stepaction.sh` | Wrapper that runs the Python generator. |
+| `hack/generate-stepaction.py` | Derives the StepAction from the Task (workspaces → params). |
+| `hack/release.sh` | Release automation: bump version → regenerate → changelog → commit → tag → push. |
+| `hack/apply-ah-changes.py` | Injects the `artifacthub.io/changes` annotation during release. |
+| `test/` | e2e runners (`e2e-tests.sh`, `e2e-bundle-test.sh`). |
+| `keys/` | `cosign.pub` (bundle verification) and signing material. |
+| `.github/workflows/` | `build.yaml` (test/verify/e2e), `release.yaml` (bundle publish), `base-image.yaml` (multi-arch base image). |
+
+### Why generate the StepAction?
+
+- **Deterministic:** CI regenerates the StepAction and diffs it against what's
+  committed (the *Verify StepAction is in sync* step in `build.yaml`). The
+  committed file must match exactly.
+- **DRY:** The StepAction is a mechanical transform of the Task, so behaviour
+  stays in lockstep instead of being maintained by hand in two places.
+
+## How generation works
+
+Run:
+
+```bash
+./hack/generate-stepaction.sh
+```
+
+Requirements: `python3` with **PyYAML**. If PyYAML isn't importable directly,
+the wrapper falls back to `uv tool run --with pyyaml`.
+
+`generate-stepaction.py` parses the Task, takes its single step, and produces a
+clean StepAction:
+
+- **Workspaces become params.** The `output`, `ssh-directory`, `basic-auth`,
+  and `ssl-ca-directory` workspaces map to `output-path`,
+  `ssh-directory-path`, `basic-auth-path`, and `ssl-ca-directory-path` params.
+- **Env vars are rewritten.** `WORKSPACE_*_PATH` env vars become `PARAM_*`
+  env vars sourced from `$(params.*-path)`; the `WORKSPACE_*_BOUND` booleans
+  are dropped (the script tests `!= ""` on the path instead).
+- **Script references are rewritten.** `${WORKSPACE_OUTPUT_PATH}` →
+  `${PARAM_OUTPUT_PATH}` etc., and `$(results.*)` → `$(step.results.*)`.
+  Scripts use shell env vars (never `$(params.*)`) because `$(params.*)`
+  substitution is **not allowed in StepAction scripts**.
+- **Descriptions are reworded** ("This Task" → "This StepAction").
+- **The `tekton.dev/signature` annotation is dropped.**
+- The task params (`url`, `revision`, `gitInitImage`, …) and results
+  (`commit`, `url`, …) are carried over.
+
+The generated file starts with a `# This file is generated …` header.
+
+## Modifying the Task or StepAction
+
+To change cloning behaviour, parameters, or results:
+
+1. Edit `task/git-clone/git-clone.yaml`.
+2. Regenerate the StepAction:
+   ```bash
+   ./hack/generate-stepaction.sh
+   ```
+3. Review both files and commit them together.
+
+If you add or rename a workspace/param that affects the StepAction mapping,
+update the `WORKSPACE_PARAMS` / `WORKSPACE_ENV_MAP` tables and the
+`transform_*` functions in `hack/generate-stepaction.py`, then regenerate.
+
+## Building the image
+
+The Task runs the `git-init` binary, shipped as the `gitInitImage`. Build it
+locally with [`ko`](https://ko.build/):
+
+```bash
+cd image/git-init
+ko build --local .
+```
+
+Point the Task at a local build for testing via the `GIT_INIT_IMAGE`
+environment variable understood by the e2e scripts (see below). The base image
+(`image/base/Dockerfile`) is built and pushed multi-arch by
+`.github/workflows/base-image.yaml`.
+
+## Running tests locally
+
+The Go unit tests live under `image/git-init`:
+
+```bash
+cd image/git-init
+go build ./...
+go vet ./...
+go test ./...
+```
+
+E2e tests run against a real Tekton install in a local
+[kind](https://kind.sigs.k8s.io/) cluster:
+
+```bash
+kind create cluster
+
+# Task: install it and run every TaskRun in tests/run.yaml
+./test/e2e-tests.sh
+
+# Bundle: push the Task as a Tekton bundle and resolve it via the bundle resolver
+./test/e2e-bundle-test.sh
+```
+
+Useful environment variables:
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `PIPELINE_VERSION` | `v1.12.0` | Tekton Pipelines release to install |
+| `TIMEOUT` | `120s` | Per-TaskRun timeout |
+| `GIT_INIT_IMAGE` | — | Override `gitInitImage` (e.g. a local `ko build`) |
+| `BUNDLE_REGISTRY` | `ttl.sh` | Registry the bundle test pushes to |
+
+CI (`build.yaml`) runs `go build/vet/test`, the *Verify StepAction is in sync*
+check, and the e2e matrix across the supported Tekton Pipelines versions.
+
+## Release process
+
+Releases are driven by `hack/release.sh`:
+
+```bash
+./hack/release.sh v1.8.0 --dry-run        # preview the diff (no changes applied)
+./hack/release.sh v1.8.0 --dry-run --llm  # preview with a gh copilot changelog
+./hack/release.sh v1.8.0                   # bump, regenerate, commit, tag, push
+```
+
+What it does:
+
+1. Validates the version (`vX.Y.Z`) and that you're on an up-to-date `main`.
+2. Bumps the `app.kubernetes.io/version` label and image/bundle tags in the
+   Task, StepAction, and `README.md`.
+3. Builds a changelog from conventional-commit prefixes (or via `gh copilot`
+   with `--llm`) and injects it as an `artifacthub.io/changes` annotation
+   (`hack/apply-ah-changes.py`).
+4. Regenerates the StepAction from the bumped Task.
+5. Commits (`--signoff`), pushes `main`, creates an annotated tag, and pushes
+   the tag.
+
+The tag push triggers `.github/workflows/release.yaml`, which publishes a
+cosign-signed Tekton bundle and signs the `ko` image.
+
+> [!NOTE]
+> Tekton **Trusted Resources** signing (`tkn task sign`) is intentionally not
+> done in-repo. It's blocked upstream by
+> [tektoncd/cli#2894](https://github.com/tektoncd/cli/issues/2894) and
+> [tektoncd/cli#2895](https://github.com/tektoncd/cli/issues/2895). The
+> released bundle and image are cosign-signed in the release workflow instead.
+
+## Downstream usage
+
+The Task and StepAction are consumed directly (raw URL, `kubectl apply`) or via
+the published cosign-signed Tekton bundle. See [README.md](README.md) for
+installation and bundle-resolver examples.
+
+## See also
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contribution workflow and CI expectations.
+- [AGENTS.md](AGENTS.md) — quick reference for AI coding agents.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,7 +37,7 @@ Key files:
 | `hack/release.sh` | Release automation: bump version → regenerate → changelog → commit → tag → push. |
 | `hack/apply-ah-changes.py` | Injects the `artifacthub.io/changes` annotation during release. |
 | `test/` | e2e runners (`e2e-tests.sh`, `e2e-bundle-test.sh`). |
-| `keys/` | `cosign.pub` (bundle verification) and signing material. |
+| `keys/` | `cosign.pub`, the public key for verifying signed release bundles. |
 | `.github/workflows/` | `build.yaml` (test/verify/e2e), `release.yaml` (bundle publish), `base-image.yaml` (multi-arch base image). |
 
 ### Why generate the StepAction?
@@ -126,7 +126,8 @@ E2e tests run against a real Tekton install in a local
 ```bash
 kind create cluster
 
-# Task: install it and run every TaskRun in tests/run.yaml
+# Task: install it and run every TaskRun in task/git-clone/tests/run.yaml
+# (and stepaction/git-clone/tests/run.yaml)
 ./test/e2e-tests.sh
 
 # Bundle: push the Task as a Tekton bundle and resolve it via the bundle resolver

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ spec:
 
 - **[Task reference](task/git-clone/README.md)** — full parameter, workspace, and authentication docs
 - **[StepAction reference](stepaction/git-clone/README.md)** — composable step version
+- **[DEVELOPMENT.md](DEVELOPMENT.md)** — architecture, generation, testing, and release process
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — contribution workflow and CI expectations
+- **[AGENTS.md](AGENTS.md)** — quick reference for AI coding agents
 
 ## Building
 


### PR DESCRIPTION
## Summary

Adds contributor-facing documentation explaining the repo's generation framework, testing, and release process. Closes #125.

Follows the same pattern as tektoncd-catalog/golang#31, adapted to git-clone's actual structure (the `git-clone` Task is the source of truth, and the StepAction is derived from it via `hack/generate-stepaction.py` — git-clone does not use the `base/` + `catalog.yaml` model).

## Files

- **`DEVELOPMENT.md`** — architecture overview (Task → StepAction derivation), how generation works, modifying the Task/StepAction, building the `git-init` image, running unit + e2e tests, and the `release.sh` flow.
- **`CONTRIBUTING.md`** — DCO/EasyCLA sign-off, PR workflow, conventional commits, and CI expectations (Build & Test, *Verify StepAction is in sync*, e2e matrix).
- **`AGENTS.md`** — repo structure, critical invariants (never edit `stepaction/` directly, no `$(params.*)` in scripts, workspace→param mapping), common commands, and common pitfalls.
- **`README.md`** — links to the new docs.

## Notes

All content was derived from the actual `hack/` scripts and `.github/workflows/`, including the Trusted Resources signing caveat (blocked by tektoncd/cli#2894 / #2895; bundle + image are cosign-signed in the release workflow instead).