### PR TITLE
ci: make e2e tests more robust against flakes

### DIFF
--- a/test/e2e-bundle-test.sh
+++ b/test/e2e-bundle-test.sh
@@ -38,8 +38,18 @@ BUNDLE_REF="${BUNDLE_REGISTRY}/git-clone-e2e-$(head -c 8 /proc/sys/kernel/random
 echo "--- Installing Tekton Pipelines ${PIPELINE_VERSION}"
 kubectl apply --filename "https://github.com/tektoncd/pipeline/releases/download/${PIPELINE_VERSION}/release.yaml"
 echo "--- Waiting for Tekton Pipelines to be ready"
-kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-controller -n tekton-pipelines
-kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-webhook -n tekton-pipelines
+# Wait for every control-plane deployment to be Available (cold kind nodes may
+# still be pulling images), then wait for the admission webhook to actually
+# have ready endpoints before applying any Tekton resources.
+kubectl wait --for=condition=available --timeout=300s \
+    deployment --all -n tekton-pipelines
+for _ in $(seq 1 30); do
+    if [[ -n "$(kubectl get endpoints tekton-pipelines-webhook \
+        -n tekton-pipelines -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null)" ]]; then
+        break
+    fi
+    sleep 5
+done
 
 # Prepare YAMLs (with optional image override)
 TASK_YAML=$(mktemp)

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -32,8 +32,22 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 echo "--- Installing Tekton Pipelines ${PIPELINE_VERSION}"
 kubectl apply --filename "https://github.com/tektoncd/pipeline/releases/download/${PIPELINE_VERSION}/release.yaml"
 echo "--- Waiting for Tekton Pipelines to be ready"
-kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-controller -n tekton-pipelines
-kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-webhook -n tekton-pipelines
+# Wait for every control-plane deployment to be Available, not just the
+# controller/webhook. A cold kind node may still be pulling images, so allow a
+# generous timeout.
+kubectl wait --for=condition=available --timeout=300s \
+    deployment --all -n tekton-pipelines
+# `available` is not enough: the admission webhook must actually have ready
+# endpoints before we apply Tasks/TaskRuns, otherwise applies race against an
+# unserved webhook. Wait until the webhook endpoints are populated.
+echo "--- Waiting for the admission webhook to serve"
+for _ in $(seq 1 30); do
+    if [[ -n "$(kubectl get endpoints tekton-pipelines-webhook \
+        -n tekton-pipelines -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null)" ]]; then
+        break
+    fi
+    sleep 5
+done
 
 echo "--- Installing git-clone task"
 if [[ -n "${GIT_INIT_IMAGE:-}" ]]; then
@@ -58,6 +72,12 @@ kubectl apply -f "${ROOT_DIR}/task/git-clone/tests/run.yaml"
 echo "--- Creating test TaskRuns (stepaction)"
 kubectl apply -f "${ROOT_DIR}/stepaction/git-clone/tests/run.yaml"
 
+# Source manifests, used to recreate a TaskRun if it hits a transient flake.
+RUN_FILES=(
+    "${ROOT_DIR}/task/git-clone/tests/run.yaml"
+    "${ROOT_DIR}/stepaction/git-clone/tests/run.yaml"
+)
+
 # Collect all TaskRun names
 TASKRUNS=$(kubectl get taskrun -o name | sed 's|taskrun.tekton.dev/||')
 
@@ -65,24 +85,52 @@ FAILED=0
 PASSED=0
 TOTAL=0
 
+# wait_for_taskrun waits for a single TaskRun to succeed, returning 0/1.
+wait_for_taskrun() {
+    kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" taskrun/"$1" 2>/dev/null
+}
+
+# dump_taskrun prints status + pod logs for a failed TaskRun.
+dump_taskrun() {
+    echo "  --- TaskRun status ---"
+    kubectl get taskrun/"$1" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
+    echo ""
+    echo "  --- Pod logs ---"
+    local pod
+    pod=$(kubectl get taskrun/"$1" -o jsonpath='{.status.podName}' 2>/dev/null)
+    if [[ -n "${pod}" ]]; then
+        kubectl logs "${pod}" --all-containers 2>/dev/null || true
+    fi
+    echo "  ---"
+}
+
 echo "--- Waiting for TaskRuns to complete (timeout: ${TIMEOUT})"
 for tr in ${TASKRUNS}; do
     TOTAL=$((TOTAL + 1))
     echo -n "  ${tr} ... "
-    if kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" taskrun/"${tr}" 2>/dev/null; then
+    if wait_for_taskrun "${tr}"; then
+        echo "PASSED"
+        PASSED=$((PASSED + 1))
+        continue
+    fi
+
+    # Retry once: transient pod sandbox / network / image-pull blips on a
+    # single-node kind cluster (many pods starting at once) can stall a pod
+    # before its container ever runs. Recreate the TaskRun from its source
+    # manifest and wait again before declaring a real failure.
+    echo -n "FLAKY, retrying ... "
+    kubectl delete taskrun/"${tr}" --wait=true 2>/dev/null || true
+    for f in "${RUN_FILES[@]}"; do
+        # Re-apply is a no-op for the already-completed TaskRuns and recreates
+        # the one we just deleted.
+        kubectl apply -f "${f}" >/dev/null 2>&1 || true
+    done
+    if wait_for_taskrun "${tr}"; then
         echo "PASSED"
         PASSED=$((PASSED + 1))
     else
         echo "FAILED"
-        echo "  --- TaskRun status ---"
-        kubectl get taskrun/"${tr}" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
-        echo ""
-        echo "  --- Pod logs ---"
-        pod=$(kubectl get taskrun/"${tr}" -o jsonpath='{.status.podName}' 2>/dev/null)
-        if [[ -n "${pod}" ]]; then
-            kubectl logs "${pod}" --all-containers 2>/dev/null || true
-        fi
-        echo "  ---"
+        dump_taskrun "${tr}"
         FAILED=$((FAILED + 1))
     fi
 done


### PR DESCRIPTION
## Summary

Makes the e2e test runners resilient to two distinct flakes observed in CI (e.g. on #126, which is docs-only yet had E2E jobs fail).

## Flake modes diagnosed

**1. Control-plane readiness race** (`E2E (v1.6.2)`)
```
error: timed out waiting for the condition on deployments/tekton-pipelines-controller
```
- The 120s wait on just the controller/webhook deployments was too tight on a cold kind node still pulling images.
- `deployment available` also doesn't guarantee the admission webhook has *ready endpoints*, so the subsequent `kubectl apply` of the Task can race an unserved webhook.

**2. Pod sandbox contention** (`E2E (v1.9.3)`, `git-clone-run-delete-existing`)
```
pod status "PodReadyToStartContainers":"False"; message: ""   (empty logs)
```
- All 14 TaskRuns are created at once on a single-node kind cluster; one pod stalled at sandbox/network setup and never started its container. Nothing to do with git-clone logic.

## Changes

- **Harden readiness wait** (both `e2e-tests.sh` and `e2e-bundle-test.sh`): wait for *all* `tekton-pipelines` deployments (300s) and poll the `tekton-pipelines-webhook` endpoints until populated before applying any Tekton resources.
- **Retry a TaskRun once** in `e2e-tests.sh` (delete + re-apply from its source manifest) before declaring failure, to absorb transient pod-startup blips.

No change to the Task, StepAction, or test fixtures — test-runner robustness only.