### PR TITLE
feat: add commit-tag result to git-clone

### DIFF
--- a/stepaction/git-clone/git-clone.yaml
+++ b/stepaction/git-clone/git-clone.yaml
@@ -134,6 +134,9 @@ spec:
     name: url
   - description: The epoch timestamp of the commit that was fetched by this StepAction.
     name: committer-date
+  - description: The Git tag pointing at the fetched commit, or a fallback (git describe
+      / shortsha).
+    name: commit-tag
   image: $(params.gitInitImage)
   env:
   - name: HOME
@@ -261,3 +264,10 @@ spec:
     printf "%s" "${RESULT_COMMITTER_DATE}" > "$(step.results.committer-date.path)"
     printf "%s" "${RESULT_SHA}" > "$(step.results.commit.path)"
     printf "%s" "${PARAM_URL}" > "$(step.results.url.path)"
+
+    git fetch origin 'refs/tags/*:refs/tags/*' --depth=1 2>/dev/null || git fetch origin 'refs/tags/*:refs/tags/*' 2>/dev/null || true
+    COMMIT_TAG="$(git tag --points-at HEAD | head -n1)"
+    if [ -z "${COMMIT_TAG}" ] ; then
+      COMMIT_TAG="$(git describe --tags --always 2>/dev/null || echo "no-tag")"
+    fi
+    printf "%s" "${COMMIT_TAG}" > "$(step.results.commit-tag.path)"

--- a/stepaction/git-clone/tests/run.yaml
+++ b/stepaction/git-clone/tests/run.yaml
@@ -71,3 +71,30 @@ spec:
   workspaces:
     - name: output
       emptyDir: {}
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: git-clone-stepaction-commit-tag
+spec:
+  taskSpec:
+    workspaces:
+      - name: output
+    steps:
+      - ref:
+          name: git-clone
+        params:
+          - name: url
+            value: https://github.com/kelseyhightower/nocode
+          - name: revision
+            value: "1.0.0"
+          - name: depth
+            value: "0"
+          - name: output-path
+            value: $(workspaces.output.path)
+  podTemplate:
+    securityContext:
+      fsGroup: 65532
+  workspaces:
+    - name: output
+      emptyDir: {}

--- a/task/git-clone/README.md
+++ b/task/git-clone/README.md
@@ -79,6 +79,7 @@ spec:
 | `commit` | The precise commit SHA that was fetched |
 | `url` | The precise URL that was fetched |
 | `committer-date` | The epoch timestamp of the fetched commit |
+| `commit-tag` | The Git tag pointing at the fetched commit, or a fallback (git describe / shortsha) |
 
 ## Platforms
 

--- a/task/git-clone/git-clone.yaml
+++ b/task/git-clone/git-clone.yaml
@@ -117,6 +117,8 @@ spec:
     name: url
   - description: The epoch timestamp of the commit that was fetched by this Task.
     name: committer-date
+  - description: The Git tag pointing at the fetched commit, or a fallback (git describe / shortsha).
+    name: commit-tag
   steps:
   - env:
     - name: HOME
@@ -249,6 +251,13 @@ spec:
       printf "%s" "${RESULT_COMMITTER_DATE}" > "$(results.committer-date.path)"
       printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
       printf "%s" "${PARAM_URL}" > "$(results.url.path)"
+
+      git fetch origin 'refs/tags/*:refs/tags/*' --depth=1 2>/dev/null || git fetch origin 'refs/tags/*:refs/tags/*' 2>/dev/null || true
+      COMMIT_TAG="$(git tag --points-at HEAD | head -n1)"
+      if [ -z "${COMMIT_TAG}" ] ; then
+        COMMIT_TAG="$(git describe --tags --always 2>/dev/null || echo "no-tag")"
+      fi
+      printf "%s" "${COMMIT_TAG}" > "$(results.commit-tag.path)"
     securityContext:
       runAsNonRoot: true
       runAsUser: 65532

--- a/task/git-clone/tests/run.yaml
+++ b/task/git-clone/tests/run.yaml
@@ -207,3 +207,24 @@ spec:
       value: https://github.com/kelseyhightower/nocode
     - name: sparseCheckoutDirectories
       value: "CONTRIBUTING.md,STYLE.md"
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: git-clone-run-commit-tag
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  podTemplate:
+    securityContext:
+      fsGroup: 65532
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: revision
+      value: 1.0.0
+    - name: depth
+      value: "0"


### PR DESCRIPTION
# Changes

Adds a new `commit-tag` result to the `git-clone` Task and StepAction, exposing
the git tag pointing at the fetched commit for use by downstream Tasks (e.g.
image tagging in CI pipelines).

**Behavior:**
- If the fetched commit has a tag pointing directly at it, `commit-tag` is that tag.
- Otherwise, falls back to `git describe --tags --always`.
- If no tags exist at all, falls back to `"no-tag"`.

**Depth requirement:** tag resolution requires a non-shallow clone. With the
default `depth: "1"`, the tagged commit may be outside the shallow fetch
window, causing `commit-tag` to resolve to `no-tag` even when a tag exists
upstream. Consumers needing reliable resolution should set `depth: "0"` (or
large enough to include the tagged commit).

**Testing:** added fixtures to both `task/git-clone/tests/run.yaml` and
`stepaction/git-clone/tests/run.yaml`. Per existing test infra
(`test/e2e-tests.sh`), these only validate that the TaskRun reaches
`Succeeded`, not result content — manually verified content correctness
against `kelseyhightower/nocode@1.0.0` for both variants (Task and
StepAction), confirming `commit-tag: 1.0.0` in both cases.

# Submitter Checklist
- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) for new or changed functionality
- [x] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) for user-facing changes
- [x] Commit messages follow [best practices](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)

# Release Notes
```release-note
Add new `commit-tag` result to `git-clone` Task and StepAction, exposing the git tag pointing at the fetched commit (or a fallback) for downstream use.
```