### PR TITLE
chore: group dependabot updates and fix gomod path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,28 @@
 version: 2
 updates:
   - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/git" # Location of package manifests
+    directory: "/image/git-init" # Location of go.mod
     schedule:
       interval: "daily"
+    groups:
+      go-dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/image/base"
     schedule:
       interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
<!-- Thank you for the PR! -->

# Changes

Update the Dependabot configuration to reduce PR noise and fix a broken path:

- **Fix `gomod` directory**: it pointed at a non-existent `/git` path instead of `/image/git-init` where `go.mod` actually lives — Go dependency updates were effectively not happening.
- **Group `github-actions`** updates into a single PR (`patterns: ["*"]`), matching the tektoncd/pipeline style.
- **Group `gomod`** minor + patch updates into a single `go-dependencies` PR; major bumps stay individual for review.
- **Group `docker`** base-image updates into a single PR.

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) for new or changed functionality
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) for user-facing changes
- [x] Commit messages follow [best practices](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)

# Release Notes

```release-note
NONE
```